### PR TITLE
default image needs to be 20gb

### DIFF
--- a/jenkins-config/clouds/openstack/cattle/cloud.cfg
+++ b/jenkins-config/clouds/openstack/cattle/cloud.cfg
@@ -6,7 +6,7 @@ CLOUD_ZONE=sjc1
 
 # Default Template Configuration
 IMAGE_NAME=ZZCI - CentOS 7 - builder - x86_64 - 20191113-195931.249
-VOLUME_SIZE=10
+VOLUME_SIZE=20
 HARDWARE_ID=v2-highcpu-1
 NETWORK_ID=515df75a-196e-4d38-9e50-137b7c83c8e7
 USER_DATA_ID=jenkins-init-script


### PR DESCRIPTION
jenkins.plugins.openstack.compute.internal.Openstack$ActionFailed: Failed to boot server prd-centos7-builder-1c-1g-183: status=ERROR vmState=error fault=500: Build of instance a51d9d1b-2166-4a32-a3bf-1685ddd01eec aborted: Invalid input received: Invalid input received: Size of specified image 20GB is larger than volume size 10GB. (HTTP 400) (Request-ID: req-88aec24c-1cd4-4ab6-936c-cd108739d486) (null)