### PR TITLE
Feat!: Remove Ubuntu 16.04 jobs and packer files

### DIFF
--- a/jjb/ci-management/packer.yaml
+++ b/jjb/ci-management/packer.yaml
@@ -11,7 +11,6 @@
 
     platforms:
       - centos-7
-      - ubuntu-16.04
       - ubuntu-18.04
 
     templates: builder
@@ -31,5 +30,4 @@
 
     platforms:
       - centos-7
-      - ubuntu-16.04
       - ubuntu-18.04

--- a/packer/vars/ubuntu-16.04.json
+++ b/packer/vars/ubuntu-16.04.json
@@ -1,6 +1,0 @@
-{
-  "base_image": "LF - Ubuntu 16.04 LTS (2018-08-31)",
-  "distro": "Ubuntu 16.04",
-  "ssh_user": "ubuntu",
-  "cloud_user_data": null
-}


### PR DESCRIPTION
Ubuntu 16.04 is EOL and no longer supported.

Signed-off-by: Anil Belur <abelur@linuxfoundation.org>